### PR TITLE
Fix collapse issue with latest dojo version

### DIFF
--- a/Support.js
+++ b/Support.js
@@ -235,7 +235,7 @@ function (query, lang, attr, domStyle, array, json, has, on) {
                         data = this.setData(node, key, def);
                     }
                 }
-                return (lang.isArray(data) && data.length > 0) ? data[0] : data;
+                return (data instanceof Array && data.length > 0) ? data[0] : data;
             } else {
                 _loadData.call(this, node);
                 return query(node).data()[0];


### PR DESCRIPTION
Dojo collapse doesn't work with latest dojo version, in dojo bootstrap, support.js uses dojo lang.isArray to check if data is array, which returns false even when data is an array since Dojo lang has changed the way to check an array, it causes collapse not working. The solution is to use JavaScript  data instanceof Array instead of dojo lang.isArray
